### PR TITLE
Php8.0 fixes

### DIFF
--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -1811,7 +1811,8 @@ class TCPDF_STATIC {
 		$flags = $flags === null ? 0 : $flags;
 		// the bug only happens on PHP 5.2 when using the u modifier
 		if ((strpos($modifiers, 'u') === FALSE) OR (count(preg_split('//u', "\n\t", -1, PREG_SPLIT_NO_EMPTY)) == 2)) {
-			return preg_split($pattern.$modifiers, $subject, $limit, $flags);
+			$ret = preg_split($pattern.$modifiers, $subject, $limit, $flags);
+            return is_array($ret) ? $ret : array();
 		}
 		// preg_split is bugged - try alternative solution
 		$ret = array();
@@ -2154,7 +2155,7 @@ class TCPDF_STATIC {
 	 * Array of page formats
 	 * measures are calculated in this way: (inches * 72) or (millimeters * 72 / 25.4)
 	 * @public static
-	 * 
+	 *
      * @var array<string,float[]>
 	 */
 	public static $page_formats = array(

--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -1812,7 +1812,7 @@ class TCPDF_STATIC {
 		// the bug only happens on PHP 5.2 when using the u modifier
 		if ((strpos($modifiers, 'u') === FALSE) OR (count(preg_split('//u', "\n\t", -1, PREG_SPLIT_NO_EMPTY)) == 2)) {
 			$ret = preg_split($pattern.$modifiers, $subject, $limit, $flags);
-            return is_array($ret) ? $ret : array();
+			return is_array($ret) ? $ret : array();
 		}
 		// preg_split is bugged - try alternative solution
 		$ret = array();

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -6854,8 +6854,8 @@ class TCPDF {
 		}
 		// resize the block to be contained on the remaining available page or column space
 		if ($fitonpage) {
-            // fallback to avoid division by zero
-            $h = $h == 0 ? 1 : $h;
+			// fallback to avoid division by zero
+			$h = $h == 0 ? 1 : $h;
 			$ratio_wh = ($w / $h);
 			if (($y + $h) > $this->PageBreakTrigger) {
 				$h = $this->PageBreakTrigger - $y;

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -6395,7 +6395,7 @@ class TCPDF {
 		// calculate maximum width for a single character on string
 		$chrw = $this->GetArrStringWidth($chars, '', '', 0, true);
 		array_walk($chrw, array($this, 'getRawCharWidth'));
-		$maxchwidth = max($chrw);
+		$maxchwidth = (is_array($chrw) || $chrw instanceof Countable) ? max($chrw) : 0;
 		// get array of chars
 		$uchars = TCPDF_FONTS::UTF8ArrayToUniArray($chars, $this->isunicode);
 		// get the number of characters
@@ -6854,6 +6854,8 @@ class TCPDF {
 		}
 		// resize the block to be contained on the remaining available page or column space
 		if ($fitonpage) {
+            // fallback to avoid division by zero
+            $h = $h == 0 ? 1 : $h;
 			$ratio_wh = ($w / $h);
 			if (($y + $h) > $this->PageBreakTrigger) {
 				$h = $this->PageBreakTrigger - $y;
@@ -8429,7 +8431,7 @@ class TCPDF {
 								$annots .= ' /Name /Note';
 							}
 							$hasStateModel = isset($pl['opt']['statemodel']);
-							$hasState = isset($pl['opt']['state']); 
+							$hasState = isset($pl['opt']['state']);
 							$statemodels = array('Marked', 'Review');
 							if (!$hasStateModel && !$hasState) {
 								break;


### PR DESCRIPTION
Fixes:

- DivisionByZeroError: Division by zero in tcpdf.php -> public function Write
- ValueError: max(): Argument #1 ($value) must contain at least one element in tcpdf.php -> protected function fitBlock
- TypeError: array_map(): Argument #2 ($array) must be of type array, bool given in tcpdf/include/tcpdf_fonts.php caused by static function pregSplit returning bool instead of empty array